### PR TITLE
Update new actions owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A GitHub Action to roughly calculate DORA deployment frequency. This is not mean
 
 To test the current repo (same as where the action runs)
 ```
-- uses: samsmithnz/deployment-frequency@main
+- uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI'
 ```
@@ -35,7 +35,7 @@ To test the current repo (same as where the action runs)
 To test another repo, with all arguments
 ```
 - name: Test another repo
-  uses: samsmithnz/deployment-frequency@main
+  uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI/CD'
     owner-repo: 'samsmithnz/DevOpsMetrics'
@@ -46,7 +46,7 @@ To test another repo, with all arguments
 To use a PAT token to access another (potentially private) repo:
 ```
 - name: Test elite repo with PAT Token
-  uses: samsmithnz/deployment-frequency@main
+  uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI/CD'
     owner-repo: 'samsmithnz/SamsFeatureFlags'
@@ -56,7 +56,7 @@ To use a PAT token to access another (potentially private) repo:
 Use the built in Actions GitHub Token to retrieve the metrix 
 ```
 - name: Test this repo with GitHub Token
-  uses: samsmithnz/deployment-frequency@main
+  uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI'
     actions-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -65,7 +65,7 @@ Use the built in Actions GitHub Token to retrieve the metrix
 Gather the metric from another repository using GitHub App authentication method:
 ```
 - name: Test another repo with GitHub App
-  uses: samsmithnz/deployment-frequency@main
+  uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI'
     owner-repo: 'samsmithnz/some-other-repo'

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To use a PAT token to access another (potentially private) repo:
     pat-token: "${{ secrets.PATTOKEN }}"
 ```
 
-Use the built in Actions GitHub Token to retrieve the metrix 
+Use the built in Actions GitHub Token to retrieve the metrics 
 ```
 - name: Test this repo with GitHub Token
   uses: DeveloperMetrics/deployment-frequency@main


### PR DESCRIPTION

* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R38">`README.md`</a>: Updated the usage of the `deployment-frequency` GitHub action in the code snippets. The action's repository has been changed from `samsmithnz/deployment-frequency@main` to `DeveloperMetrics/deployment-frequency@main`. <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R38">[1]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R59">[2]</a> <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R68">[3]</a>
* <a href="diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L49-R59">`README.md`</a>: Corrected a typo in the section `Use the built in Actions GitHub Token to retrieve the metrix`, changing 'metrix' to 'metrics'.