### PR TITLE
Add markdown results as output and fix actionsToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ A GitHub Action to roughly calculate DORA deployment frequency. This is not mean
 - `app-private-key`: optional, string, defaults to '', private key which has been generated for the installed instance of the GitHub app. Must be provided without leading `'-----BEGIN RSA PRIVATE KEY----- '` and trailing `' -----END RSA PRIVATE KEY-----'`.
 
 To test the current repo (same as where the action runs)
-```
+```yml
 - uses: DeveloperMetrics/deployment-frequency@main
   with:
     workflows: 'CI'
 ```
 
 To test another repo, with all arguments
-```
+```yml
 - name: Test another repo
   uses: DeveloperMetrics/deployment-frequency@main
   with:
@@ -44,7 +44,7 @@ To test another repo, with all arguments
 ```
 
 To use a PAT token to access another (potentially private) repo:
-```
+```yml
 - name: Test elite repo with PAT Token
   uses: DeveloperMetrics/deployment-frequency@main
   with:
@@ -54,7 +54,7 @@ To use a PAT token to access another (potentially private) repo:
 ```
 
 Use the built in Actions GitHub Token to retrieve the metrics 
-```
+```yml
 - name: Test this repo with GitHub Token
   uses: DeveloperMetrics/deployment-frequency@main
   with:
@@ -63,7 +63,7 @@ Use the built in Actions GitHub Token to retrieve the metrics
 ```
 
 Gather the metric from another repository using GitHub App authentication method:
-```
+```yml
 - name: Test another repo with GitHub App
   uses: DeveloperMetrics/deployment-frequency@main
   with:
@@ -72,6 +72,17 @@ Gather the metric from another repository using GitHub App authentication method
     app-id: "${{ secrets.APPID }}"
     app-install-id: "${{ secrets.APPINSTALLID }}"
     app-private-key: "${{ secrets.APPPRIVATEKEY }}"
+```
+
+Use the markdown file output for some other action downstream:
+```yml
+- name: Generate deployment frequency markdown file
+  uses: DeveloperMetrics/deployment-frequency@main
+  id: deployment-frequency
+  with:
+    workflows: 'CI'
+    actions-token: "${{ secrets.GITHUB_TOKEN }}"
+- run: cat ${{ steps.deployment-frequency.outputs.markdown-file }})
 ```
 
 # Output

--- a/action.yml
+++ b/action.yml
@@ -35,13 +35,19 @@ inputs:
   app-private-key:
     description: 'private key which has been generated for the installed instance of the GitHub app'
     default: ""
+outputs:
+  markdown-file:
+    description: "The markdown that will be posted to the job summary, so that the markdown can saved and used other places (e.g.: README.md)"
+    value: ${{ steps.deployment-frequency.outputs.markdown-file }}
 runs:
   using: "composite"
   steps:
-    - name: Run DORA deployment frequency 
+    - name: Run DORA deployment frequency
+      id: deployment-frequency
       shell: pwsh
       run: |
          $result = ${{ github.action_path }}/src/deploymentfrequency.ps1 -ownerRepo "${{ inputs.owner-repo }}" -workflows "${{ inputs.workflows }}" -branch "${{ inputs.default-branch }}" -numberOfDays ${{ inputs.number-of-days }} -patToken "${{ inputs.pat-token }}" -actionsToken "${{ inputs.actions-token }}" -appId "${{ inputs.app-id }}" -appInstallationId "${{ inputs.app-install-id }}" -appPrivateKey "${{ inputs.app-private-key }}"
-         #Write-Host "::set-output name=result::$result"
+         $filePath="dora-deployment-frequency-markdown.md"
+         Set-Content -Path $filePath -Value $result
+         "markdown-file=$filePath" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
          Write-Output $result >> $env:GITHUB_STEP_SUMMARY
-               

--- a/src/deploymentfrequency.ps1
+++ b/src/deploymentfrequency.ps1
@@ -243,8 +243,8 @@ function GetAuthHeader ([string] $patToken, [string] $actionsToken, [string] $ap
     }
     elseif (![string]::IsNullOrEmpty($actionsToken))
     {
-        Write-Host "Authentication detected: GITHUB TOKEN"  
-        $authHeader = @{Authorization=("Bearer {0}" -f $base64AuthInfo)}
+        Write-Host "Authentication detected: GITHUB TOKEN"
+        $authHeader = @{Authorization=("Bearer {0}" -f $actionsToken)}
     }
     elseif (![string]::IsNullOrEmpty($appId)) # GitHup App auth
     {


### PR DESCRIPTION
1. Write the markdown results to a file and create that file as an output (so that teams can use this markdown elsewhere, ie [creating a process to publish this to the README.md](https://github.com/joshjohanning-org/dora-metrics-actions-test/blob/29f5974cbf45f722654f22fb7a9fa79483ca38ed/.github/workflows/dora-metrics-actions.yml#L30-L64).
2. Fix `actionsToken` since it wasn't working - I think it was copy/paste error referring to wrong variable
    - It seems like one could simply remove this input and combine it with the PatToken parameter - but perhaps PowerShell is more finicky than I think between PATs and the GitHub Token.
    - For what it's worth, the `GITHUB_TOKEN` now works with both the `actions-token` and `pat-token` input ([see workflow](https://github.com/joshjohanning-org/dora-metrics-actions-test/blob/4dc2348a4d0f861824f6b3d4a1f26604f130c687/.github/workflows/dora-metrics-actions.yml#L15-L29))

same PR made in other action:
- https://github.com/DeveloperMetrics/lead-time-for-changes/pull/34